### PR TITLE
WIP: Stop slow simulation mode when not needed

### DIFF
--- a/extension.xml
+++ b/extension.xml
@@ -13,7 +13,7 @@
 		<ruleset name="3.5E" />
 	</properties>
 	
-	<announcement text="https://github.com/bmos/FG-PFRPG-Time-Manager\rPFRPG Time Manager v1.9 DEBUG:\rThis extension is a GM tool which provides an interface for easy time tracking and management.\nThis extension is heavily-based on Clock Adjuster which is the work of pr6i6e6st." font="emotefont" />
+	<announcement text="https://github.com/bmos/FG-PFRPG-Time-Manager\rPFRPG Time Manager v1.9 WIP limited slow simulation:\rThis extension is a GM tool which provides an interface for easy time tracking and management.\nThis extension is heavily-based on Clock Adjuster which is the work of pr6i6e6st." font="emotefont" />
 	
 	<base>
 		<includefile source="desktop/desktop_panels.xml" />

--- a/extension.xml
+++ b/extension.xml
@@ -13,7 +13,7 @@
 		<ruleset name="3.5E" />
 	</properties>
 	
-	<announcement text="https://github.com/bmos/FG-PFRPG-Time-Manager\rPFRPG Time Manager v1.9:\rThis extension is a GM tool which provides an interface for easy time tracking and management.\nThis extension is heavily-based on Clock Adjuster which is the work of pr6i6e6st." font="emotefont" />
+	<announcement text="https://github.com/bmos/FG-PFRPG-Time-Manager\rPFRPG Time Manager v1.9 DEBUG:\rThis extension is a GM tool which provides an interface for easy time tracking and management.\nThis extension is heavily-based on Clock Adjuster which is the work of pr6i6e6st." font="emotefont" />
 	
 	<base>
 		<includefile source="desktop/desktop_panels.xml" />

--- a/scripts/longtermeffects.lua
+++ b/scripts/longtermeffects.lua
@@ -193,7 +193,7 @@ local function nextRound_new(nRounds, bTimeChanged)
 		-- check if full rounds processing is unecessary
 		if shouldSwitchToQuickSimulation() then
 			-- Debug.chat("[ Skipping is ok from " .. nCurrent .. "]");
-			advanceRoundsOnTimeChanged(nRounds - i) -- Probably force update in Combat window too?
+			advanceRoundsOnTimeChanged(nRounds + 1 - i)
 			break
 		end
 		-- end checking for full rounds processing

--- a/scripts/longtermeffects.lua
+++ b/scripts/longtermeffects.lua
@@ -22,7 +22,7 @@ function advanceRoundsOnTimeChanged(nRounds)
 	end
 end
 
-function onEffectAddStart_new(rEffect)
+local function onEffectAddStart_new(rEffect)
 	rEffect.nDuration = rEffect.nDuration or 1;
 	if rEffect.sUnits == "minute" then
 		rEffect.nDuration = rEffect.nDuration * 10;

--- a/scripts/longtermeffects.lua
+++ b/scripts/longtermeffects.lua
@@ -83,34 +83,34 @@ local function EffectTypeShouldBeChecked(sEffectComponentType)
 	return inTable(arrsComponentsToInclude, sEffectComponentType)
 end
 
-local function ActorRequiresSlowMode(actor, arrSEffects)
-	local actorHealth = ActorHealthManager.getHealthStatus(actor)
+local function ActorRequiresSlowMode(rActor, arrSEffects)
+	local sActorHealth = ActorHealthManager.getHealthStatus(rActor)
 
 	-- Has ongoing damage, and still lives.
 	if inTable(arrSEffects, 'DMGO') then
-		if actorHealth ~= ActorHealthManager.STATUS_DEAD then
+		if sActorHealth ~= ActorHealthManager.STATUS_DEAD then
 			return true
 		end
 	end
 
 	-- Healing through Regeneration
 	if inTable(arrSEffects, 'REGEN') then
-		if actorHealth ~= ActorHealthManager.STATUS_HEALTHY then
+		if sActorHealth ~= ActorHealthManager.STATUS_HEALTHY then
 			return true
 		end
 	end
 	-- Healing through Fast Healing
 	if inTable(arrSEffects, 'FHEAL') then
-		if actorHealth ~= ActorHealthManager.STATUS_HEALTHY and actorHealth ~= ActorHealthManager.STATUS_DEAD then
+		if sActorHealth ~= ActorHealthManager.STATUS_HEALTHY and sActorHealth ~= ActorHealthManager.STATUS_DEAD then
 			return true
 		end
 	end
 	return false
 end
 
-local function IsActorDying(actor, bIsStable)
-	local actorHealth = ActorHealthManager.getHealthStatus(actor)
-	if not bIsStable and actorHealth == ActorHealthManager.STATUS_DYING then
+local function IsActorDying(rActor, bIsStable)
+	local sActorHealth = ActorHealthManager.getHealthStatus(rActor)
+	if not bIsStable and sActorHealth == ActorHealthManager.STATUS_DYING then
 		return true
 	end
 	return false
@@ -139,14 +139,15 @@ end
 local function shouldSwitchToQuickSimulation()
 	for _, nodeCT in pairs(DB.getChildren('combattracker.list')) do
 		-- Debug.console(ActorManager.getName(nodeCT))
-		local bIsStable = false
+		local bIsStable
 		local aEffectsToCheck = {}
-		local actor = ActorManager.resolveActor(nodeCT) -- maybe extract health too, instead of doing it twice. But it makes naming functions harded. IDK.
+		local rActor = ActorManager.resolveActor(nodeCT) -- maybe extract health too, instead of doing it twice. But it makes naming functions harder. IDK.
 		bIsStable, aEffectsToCheck = getIsStableAndEffectsToCheck(nodeCT)
-		if ActorRequiresSlowMode(actor, aEffectsToCheck) then
-			return false -- we can leave early if there is at least one node requiring simulation
+		if ActorRequiresSlowMode(rActor, aEffectsToCheck) then
+			-- leave early if there is at least one node requiring simulation
+			return
 		end
-		if IsActorDying(actor, bIsStable) then
+		if IsActorDying(rActor, bIsStable) then
 			return false
 		end
 	end
@@ -255,8 +256,10 @@ end
 function onInit()
 	nextRound_old = CombatManager.nextRound;
 	CombatManager.nextRound = nextRound_new;
+	
 	resetInit_old = CombatManager.resetInit;
 	CombatManager.resetInit = resetInit_new;
+	
 	clearExpiringEffects_old = CombatManager2.clearExpiringEffects;
 	CombatManager2.clearExpiringEffects = clearExpiringEffects_new;
 

--- a/scripts/longtermeffects.lua
+++ b/scripts/longtermeffects.lua
@@ -182,9 +182,7 @@ local function nextRound_new(nRounds, bTimeChanged)
 
 		-- bmos resetting rounds and advancing time
 		if (nCurrent % 10) == 9 and not bTimeChanged then
-			local nMinutes = math.floor(nCurrent / 10);
-			nCurrent = nCurrent - (nMinutes * 10);
-			CalendarManager.adjustMinutes(nMinutes);
+			CalendarManager.adjustMinutes(1);
 			CalendarManager.outputTime();
 		end
 		-- end bmos resetting rounds and advancing time
@@ -216,9 +214,7 @@ local function nextRound_new(nRounds, bTimeChanged)
 
 		-- bmos resetting rounds and advancing time
 		if (nCurrent % 10) == 9 and not bTimeChanged then
-			local nMinutes = math.floor(nCurrent / 10);
-			nCurrent = nCurrent - (nMinutes * 10);
-			CalendarManager.adjustMinutes(nMinutes);
+			CalendarManager.adjustMinutes(1);
 			CalendarManager.outputTime();
 		end
 		-- end bmos resetting rounds and advancing time

--- a/scripts/longtermeffects.lua
+++ b/scripts/longtermeffects.lua
@@ -37,9 +37,9 @@ local function resetInit_new()
 	CombatManager.onCombatResetEvent();
 end
 
-local function filterTable(table, filterFunction)
+local function filterTable(tTable, filterFunction)
 	local tFiltered = {}
-	for key, value in pairs(table) do
+	for key, value in pairs(tTable) do
 		if filterFunction(value) then
 			table.insert(tFiltered, key, value)
 		end

--- a/scripts/longtermeffects.lua
+++ b/scripts/longtermeffects.lua
@@ -181,11 +181,13 @@ function nextRound_new(nRounds, bTimeChanged)
 	end
 
 	for i = nStartCounter, nRounds do
+		-- check if full rounds processing is unecessary
 		if shouldSwitchToQuickSimulation() then
 			-- Debug.chat("[ Skipping is ok from " .. nCurrent .. "]");
-			LongTermEffects.advanceRoundsOnTimeChanged(nRounds - i) -- Probably force update in Combat window too?
+			advanceRoundsOnTimeChanged(nRounds - i) -- Probably force update in Combat window too?
 			break
 		end
+		-- end checking for full rounds processing
 
 		for i = 1,#aEntries do
 			CombatManager.onTurnStartEvent(aEntries[i]);

--- a/scripts/longtermeffects.lua
+++ b/scripts/longtermeffects.lua
@@ -66,9 +66,11 @@ local function ActorRequiresSlowMode(actor, arrSEffects)
 
 	local actorHealth = ActorHealthManager.getHealthStatus(actor)
 
-	-- Has ongoing damage
+	-- Has ongoing damage, and still lives.
 	if inTable(arrSEffects, 'DMGO') then
-		return true
+		if actorHealth ~= ActorHealthManager.STATUS_DEAD then
+			return true
+		end
 	end
 
 	-- Healing through Regeneration

--- a/scripts/longtermeffects.lua
+++ b/scripts/longtermeffects.lua
@@ -202,13 +202,13 @@ local function nextRound_new(nRounds, bTimeChanged)
 	end
 
 	for i = nStartCounter, nRounds do
-		-- check if full rounds processing is unecessary
+		-- check if full processing of rounds is unecessary
 		if shouldSwitchToQuickSimulation() then
 			-- Debug.chat("[ Skipping is ok from " .. nCurrent .. "]");
 			advanceRoundsOnTimeChanged(nRounds + 1 - i)
 			break
 		end
-		-- end checking for full rounds processing
+		-- end checking for necessity of full processing of rounds
 
 		for i = 1,#aEntries do
 			CombatManager.onTurnStartEvent(aEntries[i]);

--- a/scripts/longtermeffects.lua
+++ b/scripts/longtermeffects.lua
@@ -59,15 +59,6 @@ local function filterTable(tTable, filterFunction)
 	return tFiltered
 end
 
-local function inTable(table, checkedValue)
-	for _, value in pairs(table) do
-		if value == checkedValue then
-			return true
-		end
-	end
-	return false
-end
-
 local function splitEffectIntoComponentsTypes(sEffect)
 	local aEffectComps = EffectManager.parseEffect(sEffect)
 	local aComponentTypes = {}
@@ -80,27 +71,27 @@ end
 
 local function EffectTypeShouldBeChecked(sEffectComponentType)
 	local arrsComponentsToInclude = {'FHEAL', 'REGEN', 'DMGO'}
-	return inTable(arrsComponentsToInclude, sEffectComponentType)
+	return StringManager.contains(arrsComponentsToInclude, sEffectComponentType)
 end
 
 local function ActorRequiresSlowMode(rActor, arrSEffects)
 	local sActorHealth = ActorHealthManager.getHealthStatus(rActor)
 
 	-- Has ongoing damage, and still lives.
-	if inTable(arrSEffects, 'DMGO') then
+	if StringManager.contains(arrSEffects, 'DMGO') then
 		if sActorHealth ~= ActorHealthManager.STATUS_DEAD then
 			return true
 		end
 	end
 
 	-- Healing through Regeneration
-	if inTable(arrSEffects, 'REGEN') then
+	if StringManager.contains(arrSEffects, 'REGEN') then
 		if sActorHealth ~= ActorHealthManager.STATUS_HEALTHY then
 			return true
 		end
 	end
 	-- Healing through Fast Healing
-	if inTable(arrSEffects, 'FHEAL') then
+	if StringManager.contains(arrSEffects, 'FHEAL') then
 		if sActorHealth ~= ActorHealthManager.STATUS_HEALTHY and sActorHealth ~= ActorHealthManager.STATUS_DEAD then
 			return true
 		end

--- a/scripts/longtermeffects.lua
+++ b/scripts/longtermeffects.lua
@@ -180,11 +180,11 @@ function nextRound_new(nRounds, bTimeChanged)
 
 	for i = nStartCounter, nRounds do
 		if shouldSwitchToQuickSimulation() then
-			Debug.chat("[ Skipping is ok from " .. nCurrent .. "]");
-			-- switch to Quick Simulation
+			-- Debug.chat("[ Skipping is ok from " .. nCurrent .. "]");
+			LongTermEffects.advanceRoundsOnTimeChanged(nRounds - i) -- Probably force update in Combat window too?
+			break
 		end
 
-		-- TODO: LEAVE LOOP, take remaining time, call fast simulation.
 		for i = 1,#aEntries do
 			CombatManager.onTurnStartEvent(aEntries[i]);
 			CombatManager.onTurnEndEvent(aEntries[i]);

--- a/scripts/longtermeffects.lua
+++ b/scripts/longtermeffects.lua
@@ -220,7 +220,7 @@ function nextRound_new(nRounds, bTimeChanged)
 	-- Check option to see if we should advance to first actor or stop on round start
 	if OptionsManager.isOption("RNDS", "off") then
 		local bSkipBell = (nRounds > 1);
-		if CombatManager.getCombatantCount() > 0 then
+		if #aEntries > 0 then
 			CombatManager.nextActor(bSkipBell, true);
 		end
 	end


### PR DESCRIPTION
This PR changes adds mechanism to switch from slow/exact simulation mechanism to quick/inexact mechanism in certain conditions.

Basic idea is that slow mode should only go as long as there are effects present which would be affected by switching to quick mode:
- Any form of ongoing damage, while target is alive.
- Any form of ongoing healing, while target is not healed.
- Saving throws against dying are still to be rolled.

I had not yet measured any performance, as I need to check what tools I can use for it available in FantasyGrounds lua API.

As I have not worked with lua and FG APIs before more thorough review would be greatly appreciated.
I see that code style is bit arbitrary, and varies by extensions so I am open to adjustments.