### PR TITLE
Options for defaults

### DIFF
--- a/desktop/desktop_panels.xml
+++ b/desktop/desktop_panels.xml
@@ -198,10 +198,11 @@
 				<tooltip textres="desktop_addhour_tooltip" />
 				<script>
 					function onInit()
-						DB.setValue(getDatabaseNode(), "addhour", "number", (getValue() or 0));
+						setValue(tonumber(OptionsManager.getOption(TimeManager.CLOCKADJUSTER_DEFAULT_HOURS)) or 0);
+						OptionsManager.registerCallback(TimeManager.CLOCKADJUSTER_DEFAULT_HOURS, onOptionChanged);
 					end
-					function onClose()
-						DB.setValue(getDatabaseNode(), "addhour", "number", (getValue() or 0));
+					function onOptionChanged()
+						setValue(tonumber(OptionsManager.getOption(TimeManager.CLOCKADJUSTER_DEFAULT_HOURS)) or 0);
 					end
 					function onDoubleClick()
 						local nHour = getValue() or 0;
@@ -253,10 +254,11 @@
 				<tooltip textres="desktop_addminute_tooltip" />
 				<script>
 					function onInit()
-						DB.setValue(getDatabaseNode(), "addminute", "number", (getValue() or 0));
+						setValue(tonumber(OptionsManager.getOption(TimeManager.CLOCKADJUSTER_DEFAULT_MINUTES)) or 0);
+						OptionsManager.registerCallback(TimeManager.CLOCKADJUSTER_DEFAULT_MINUTES, onOptionChanged);
 					end
-					function onClose()
-						DB.setValue(getDatabaseNode(), "addminute", "number", (getValue() or 0));
+					function onOptionChanged()
+						setValue(tonumber(OptionsManager.getOption(TimeManager.CLOCKADJUSTER_DEFAULT_MINUTES)) or 0);
 					end
 					function onDoubleClick()
 						local nMinute = getValue() or 0;
@@ -300,12 +302,12 @@
 				<tooltip textres="desktop_addday_tooltip" />
 				<script>
 					function onInit()
-						DB.setValue(getDatabaseNode(), "addday", "number", (getValue() or 0));
+						setValue(tonumber(OptionsManager.getOption(TimeManager.CLOCKADJUSTER_DEFAULT_DAYS)) or 0);
+						OptionsManager.registerCallback(TimeManager.CLOCKADJUSTER_DEFAULT_DAYS, onOptionChanged);
 					end
-					function onClose()
-						DB.setValue(getDatabaseNode(), "addday", "number", (getValue() or 0));
+					function onOptionChanged()
+						setValue(tonumber(OptionsManager.getOption(TimeManager.CLOCKADJUSTER_DEFAULT_DAYS)) or 0);
 					end
-					
 					function onDoubleClick()
 						local nDay = getValue() or 0;
 						local nRounds = nDay * 14400;
@@ -351,10 +353,11 @@
 				<tooltip textres="desktop_addmonth_tooltip" />
 				<script>
 					function onInit()
-						DB.setValue(getDatabaseNode(), "addmonth", "number", (getValue() or 0));
+						setValue(tonumber(OptionsManager.getOption(TimeManager.CLOCKADJUSTER_DEFAULT_MONTHS)) or 0);
+						OptionsManager.registerCallback(TimeManager.CLOCKADJUSTER_DEFAULT_MONTHS, onOptionChanged);
 					end
-					function onClose()
-						DB.setValue(getDatabaseNode(), "addmonth", "number", (getValue() or 0));
+					function onOptionChanged()
+						setValue(tonumber(OptionsManager.getOption(TimeManager.CLOCKADJUSTER_DEFAULT_MONTHS)) or 0);
 					end
 					function onDoubleClick()
 						local nMonth = getValue() or 0;
@@ -399,10 +402,11 @@
 				<tooltip textres="desktop_addyears_tooltip" />
 				<script>
 					function onInit()
-						DB.setValue(getDatabaseNode(), "addyear", "number", (getValue() or 0));
+						setValue(tonumber(OptionsManager.getOption(TimeManager.CLOCKADJUSTER_DEFAULT_YEARS)) or 0);
+						OptionsManager.registerCallback(TimeManager.CLOCKADJUSTER_DEFAULT_YEARS, onOptionChanged);
 					end
-					function onClose()
-						DB.setValue(getDatabaseNode(), "addyear", "number", (getValue() or 0));
+					function onOptionChanged()
+						setValue(tonumber(OptionsManager.getOption(TimeManager.CLOCKADJUSTER_DEFAULT_YEARS)) or 0);
 					end
 					function onDoubleClick()
 						local nYear = (window.addyear.getValue() or 0);

--- a/scripts/longtermeffects.lua
+++ b/scripts/longtermeffects.lua
@@ -275,8 +275,6 @@ function onInit()
 			EffectManager5E.onEffectAddStart = onEffectAddStart_new;
 		end
 	end
-
-	OptionsManager.registerOption2('TIMEROUNDS', false, 'option_header_game', 'opt_lab_time_rounds', 'option_entry_cycler', { labels = 'enc_opt_time_rounds_slow', values = 'slow', baselabel = 'enc_opt_time_rounds_fast', baseval = 'fast', default = 'fast' });
 end
 
 function onClose()

--- a/scripts/manager_time.lua
+++ b/scripts/manager_time.lua
@@ -52,7 +52,7 @@ end
 
 --- Timer Functions
 function setStartTime(nodeActor)
-	nStartTime = getCurrentDateinMinutes();
+	local nStartTime = getCurrentDateinMinutes();
 	DB.setValue(nodeActor, "starttime", "number", nStartTime);
 end
 

--- a/scripts/manager_time.lua
+++ b/scripts/manager_time.lua
@@ -11,30 +11,53 @@ CAL_CUR_MONTH = "calendar.current.month";
 CAL_CUR_YEAR = "calendar.current.year";
 CAL_NEWCAMPAIGN = "calendar.newcampaign";
 CAL_DATEINMIN = "calendar.dateinminutes"
+CLOCKADJUSTER_DEFAULT_HOURS = "CLOCKADJUSTER_DEFAULT_HOURS";
+CLOCKADJUSTER_DEFAULT_MINUTES = "CLOCKADJUSTER_DEFAULT_MINUTES";
+CLOCKADJUSTER_DEFAULT_DAYS = "CLOCKADJUSTER_DEFAULT_DAYS";
+CLOCKADJUSTER_DEFAULT_MONTHS = "CLOCKADJUSTER_DEFAULT_MONTHS";
+CLOCKADJUSTER_DEFAULT_YEARS = "CLOCKADJUSTER_DEFAULT_YEARS";
+CLOCKADJUSTER_DEFAULT_LONG = "CLOCKADJUSTER_DEFAULT_LONG";
+CLOCKADJUSTER_DEFAULT_SHORT = "CLOCKADJUSTER_DEFAULT_SHORT";
+CLOCKADJUSTER_HOURS_OPTIONS = "1|2|3|4|5|6|7|8|9|10|11|12|13|14|15|16|17|18|19|20|21|22|23";
+CLOCKADJUSTER_MINUTES_OPTIONS = "1|2|3|4|5|6|7|8|9|10|15|20|25|30|45|59";
+CLOCKADJUSTER_DAYS_OPTIONS = "1|2|3|4|5|6|7|8|9|10|15|20|25|28|29|30";
+CLOCKADJUSTER_MONTHS_OPTIONS = "1|2|3|4|5|6|7|8|9|10|11";
+CLOCKADJUSTER_YEARS_OPTIONS = "1|2|3|4|5|6|7|8|9|10|15|20|25|50|75|100|150|200|250|500";
+CLOCKADJUSTER_LONG_OPTIONS = "1|4|8|9|10|11|12|24|36|48";
+CLOCKADJUSTER_SHORT_OPTIONS = "1|5|10|15|20|25|30|45|60|90|120";
 local bNoticePosted = false
 
 function onInit()
 	DB.addHandler("calendar.log", "onChildUpdate", onEventsChanged);
+
+	-- Options for the Clock Manager add defaults
+	OptionsManager.registerOption2(CLOCKADJUSTER_DEFAULT_HOURS, false, "option_header_CLOCKADJUSTER", "option_label_CLOCKADJUSTER_DEFAULT_HOURS", "option_entry_cycler",
+	{ baselabel = "option_CLOCKADJUSTER_ZERO", baseval = "option_CLOCKADJUSTER_ZERO", labels = CLOCKADJUSTER_HOURS_OPTIONS, values = CLOCKADJUSTER_HOURS_OPTIONS, default = "option_CLOCKADJUSTER_ZERO" });
+	OptionsManager.registerOption2(CLOCKADJUSTER_DEFAULT_MINUTES, false, "option_header_CLOCKADJUSTER", "option_label_CLOCKADJUSTER_DEFAULT_MINUTES", "option_entry_cycler",
+	{ baselabel = "option_CLOCKADJUSTER_ZERO", baseval = "option_CLOCKADJUSTER_ZERO", labels = CLOCKADJUSTER_MINUTES_OPTIONS, values = CLOCKADJUSTER_MINUTES_OPTIONS, default = "option_CLOCKADJUSTER_ZERO" });
+	OptionsManager.registerOption2(CLOCKADJUSTER_DEFAULT_DAYS, false, "option_header_CLOCKADJUSTER", "option_label_CLOCKADJUSTER_DEFAULT_DAYS", "option_entry_cycler",
+	{ baselabel = "option_CLOCKADJUSTER_ZERO", baseval = "option_CLOCKADJUSTER_ZERO", labels = CLOCKADJUSTER_DAYS_OPTIONS, values = CLOCKADJUSTER_DAYS_OPTIONS, default = "option_CLOCKADJUSTER_ZERO" });
+	OptionsManager.registerOption2(CLOCKADJUSTER_DEFAULT_MONTHS, false, "option_header_CLOCKADJUSTER", "option_label_CLOCKADJUSTER_DEFAULT_MONTHS", "option_entry_cycler",
+	{ baselabel = "option_CLOCKADJUSTER_ZERO", baseval = "option_CLOCKADJUSTER_ZERO", labels = CLOCKADJUSTER_MONTHS_OPTIONS, values = CLOCKADJUSTER_MONTHS_OPTIONS, default = "option_CLOCKADJUSTER_ZERO" });
+	OptionsManager.registerOption2(CLOCKADJUSTER_DEFAULT_YEARS, false, "option_header_CLOCKADJUSTER", "option_label_CLOCKADJUSTER_DEFAULT_YEARS", "option_entry_cycler",
+	{ baselabel = "option_CLOCKADJUSTER_ZERO", baseval = "option_CLOCKADJUSTER_ZERO", labels = CLOCKADJUSTER_YEARS_OPTIONS, values = CLOCKADJUSTER_YEARS_OPTIONS, default = "option_CLOCKADJUSTER_ZERO" });
+	OptionsManager.registerOption2(CLOCKADJUSTER_DEFAULT_LONG, false, "option_header_CLOCKADJUSTER", "option_label_CLOCKADJUSTER_DEFAULT_LONG", "option_entry_cycler",
+	{ baselabel = "option_CLOCKADJUSTER_ZERO", baseval = "option_CLOCKADJUSTER_ZERO", labels = CLOCKADJUSTER_LONG_OPTIONS, values = CLOCKADJUSTER_LONG_OPTIONS, default = "option_CLOCKADJUSTER_ZERO" });
+	OptionsManager.registerOption2(CLOCKADJUSTER_DEFAULT_SHORT, false, "option_header_CLOCKADJUSTER", "option_label_CLOCKADJUSTER_DEFAULT_SHORT", "option_entry_cycler",
+	{ baselabel = "option_CLOCKADJUSTER_ZERO", baseval = "option_CLOCKADJUSTER_ZERO", labels = CLOCKADJUSTER_SHORT_OPTIONS, values = CLOCKADJUSTER_SHORT_OPTIONS, default = "option_CLOCKADJUSTER_ZERO" });
+
+	OptionsManager.registerOption2("TIMEROUNDS", false, "option_header_CLOCKADJUSTER", "opt_lab_time_rounds", "option_entry_cycler",
+		{ labels = "enc_opt_time_rounds_slow", values = "slow", baselabel = "enc_opt_time_rounds_fast", baseval = "fast", default = "fast" });
 end
 
 --- Timer Functions
-function setStartTime(rActor, sFirst)
-	-- Debug.console("setStartTime called; " .. sFirst .."");
-	local nodeActor = rActor;
-	nStartTime = getCurrentDateinMinutes(rActor);
-	-- Debug.console("setStartTime; nStartTime =", nStartTime);
+function setStartTime(nodeActor)
+	nStartTime = getCurrentDateinMinutes();
 	DB.setValue(nodeActor, "starttime", "number", nStartTime);
-	Debug.console("setStartTime", rActor, sFirst, nStartTime, DB.getValue(nodeActor, "starttime"));
-	-- Debug.console("setStartTime; DB.setValue(nodeActor, " .. sFirst .. ".starttime, number, " .. nStartTime .. ") = ", DB.setValue(nodeActor, "" .. sFirst .. ".starttime", "number", nStartTime));
 end
 
-function getStartTime(rActor, sFirst)
-	-- Debug.console("getStartTime called; " .. sFirst .."");
-	local nodeActor = rActor;
-	FetchStartTime = DB.getValue(nodeActor, "starttime", 0);
-	-- Debug.console("setStartTime; FetchStartTime = DB.getValue(" .. nodeActor .. ", " .. sFirst .. ".starttime, " .. nStartTime .. ") = " .. DB.getValue(nodeActor, "" .. sFirst .. ".starttime", nStartTime) .. "");
-
-	return FetchStartTime;
+function getStartTime(nodeActor)
+	return DB.getValue(nodeActor, "starttime", 0);
 end
 
 function setTimerStart(rActor, sFirst)

--- a/strings/strings_options.xml
+++ b/strings/strings_options.xml
@@ -9,4 +9,15 @@
 	<!-- option states -->
 	<string name="enc_opt_time_rounds_fast">Quick Mode</string>
 	<string name="enc_opt_time_rounds_slow">Full Process</string>
+
+	<!-- option defaults -->
+	<string name="option_header_CLOCKADJUSTER">Clock Adjuster (GM)</string>
+	<string name="option_label_CLOCKADJUSTER_DEFAULT_HOURS">Default Hours</string>
+	<string name="option_label_CLOCKADJUSTER_DEFAULT_MINUTES">Default Minutes</string>
+	<string name="option_label_CLOCKADJUSTER_DEFAULT_DAYS">Default Days</string>
+	<string name="option_label_CLOCKADJUSTER_DEFAULT_MONTHS">Default Months</string>
+	<string name="option_label_CLOCKADJUSTER_DEFAULT_YEARS">Default Years</string>
+	<string name="option_label_CLOCKADJUSTER_DEFAULT_LONG">Default Long Rest (hours)</string>
+	<string name="option_label_CLOCKADJUSTER_DEFAULT_SHORT">Default Short Rest (minutes)</string>
+	<string name="option_CLOCKADJUSTER_ZERO">0</string>
 </root>


### PR DESCRIPTION
This pull request should be included if you want the default values in the clock adjuster (i.e. add hour, add minute, add day, add month, add year) to be populated from OPTIONS.